### PR TITLE
Overview Tab additions

### DIFF
--- a/Broke Breaker/Broke Breaker/Views/ListOverview/ListOverviewView.swift
+++ b/Broke Breaker/Broke Breaker/Views/ListOverview/ListOverviewView.swift
@@ -206,7 +206,6 @@ struct ListOverviewView: View {
         }
     }
 
-
     private var currencyFormatter: NumberFormatter {
         let f = NumberFormatter()
         f.numberStyle = .currency


### PR DESCRIPTION
Added:
Weeks are now swipeable
The circles are now reactive to each days net total (red or blue)
Now lists items added from the add item tab
Can now delete items in the overview tab by swiping them

<img width="496" height="618" alt="image" src="https://github.com/user-attachments/assets/21827a96-6a9b-47ba-90a0-10cf3efa85a8" />