### PR TITLE
add end date to add transactions page

### DIFF
--- a/Broke Breaker/Broke Breaker/Views/AddItem/AddItemView.swift
+++ b/Broke Breaker/Broke Breaker/Views/AddItem/AddItemView.swift
@@ -14,6 +14,8 @@ struct AddItemView: View {
     @State private var amountDigits: String = ""
     @State private var isPositive: Bool = false
     @State private var selectedDate: Date = Date()
+    @State private var hasEndDate: Bool = false
+    @State private var selectedEndDate: Date = Date()
 
     enum TxType: String, CaseIterable, Identifiable {
         case oneTime = "One-time"
@@ -223,6 +225,50 @@ struct AddItemView: View {
                         Spacer()
                     }
                     .transition(.opacity.combined(with: .move(edge: .top)))
+
+                    // End date
+                    HStack {
+                        Spacer()
+
+                        VStack(alignment: .leading, spacing: 10) {
+
+                            HStack(spacing: 10) {
+                                Text("End date")
+                                    .font(.title3.weight(.semibold))
+
+                                Toggle("", isOn: Binding(
+                                    get: { hasEndDate },
+                                    set: { on in
+                                        hasEndDate = on
+                                        if on { selectedEndDate = max(selectedEndDate, selectedDate) }
+                                    }
+                                ))
+                                .labelsHidden()
+                                .tint(createButtonColor)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 8)
+                            }
+
+                            if hasEndDate {
+                                DatePicker(
+                                    "",
+                                    selection: Binding(
+                                        get: { max(selectedEndDate, selectedDate) },
+                                        set: { selectedEndDate = max($0, selectedDate) }
+                                    ),
+                                    in: selectedDate...,
+                                    displayedComponents: [.date]
+                                )
+                                .datePickerStyle(.compact)
+                                .labelsHidden()
+                                .padding(12)
+                                .background(.ultraThinMaterial)
+                                .clipShape(RoundedRectangle(cornerRadius: 14))
+                            }
+                        }
+
+                        Spacer()
+                    }
                 }
 
                 Button(action: create) {
@@ -372,12 +418,14 @@ struct AddItemView: View {
                     case .years: return .everyYears(n)
                     }
                 }()
+                
+                let end: Date? = hasEndDate ? max(selectedEndDate, selectedDate) : nil
 
                 try ledger.addRecurring(
                     title: trimmedTitle,
                     amountPerCycle: finalAmount,
                     startDate: selectedDate,
-                    endDate: nil,
+                    endDate: end,
                     recurrence: recurrence
                 )
             }
@@ -390,6 +438,8 @@ struct AddItemView: View {
             amountDigits = ""
             isPositive = false
             selectedDate = Date()
+            hasEndDate = false
+            selectedEndDate = Date()
             everyNText = "1"
             unit = .days
             txType = .oneTime


### PR DESCRIPTION
simple stuff, this pr adds an end date to recurring transactions. this is some work that needed doing before i can get to work on the edit page. the end date is optional and only specified when a toggle is on, otherwise it is assumed to run forever.